### PR TITLE
Removing external crypto dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@iobroker/adapter-core": "^2.4.0",
     "axios": "^0.20.0",
-    "crypto": "^1.0.1",
     "flatted": "^3.1.0",
     "https": "^1.0.0",
     "mqtt": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "sinon": "^9.0.1",
     "sinon-chai": "^3.5.0"
   },
+  "engines": {
+    "node": ">= 10.0.0"
+  },
   "main": "main.js",
   "scripts": {
     "test:js": "mocha --opts test/mocha.custom.opts",

--- a/readme.md
+++ b/readme.md
@@ -56,12 +56,13 @@ Then stop the adapter, place the IP into field Hostaddress and restart the adapt
 * detect IP of devices automatically
 * collect more mqtt message acronym meanings
 * test with more different devices
-* remove deprecated library crypto
 
 ### known issues:
  * No automatic IP detection of devices
  
 ### 0.7.0 (2020-11-xx) (Afraid of the dark)
+
+* (jpwenzel) Removing crypto from package dependency list (using Node.js provided version)
 
 
 ### 0.6.0 (2020-10-29) (Rage before the storm)

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,8 @@ Connects your dyson fans, fan heaters, air purifiers and air humidifiers to ioBr
 Install from STABLE or LATEST repository or from github - depending what stability you prefer.
 
 ### Prerequisites
+
+* This adapter needs Node.js >= version 10
 * To get this adapter running you'll need a dyson account.
 * Make sure to add your fan to your account. Either via App or online.
 


### PR DESCRIPTION
Removing external dependency on the ```crypto``` module which had been deprecated. Ensuring Node.js >= 10 is required as it ships with ```crypto```.