### PR TITLE
Development

### DIFF
--- a/dysonConstants.js
+++ b/dysonConstants.js
@@ -31,7 +31,7 @@ module.exports.DATAPOINTS = [
     ['channel', 'WIFIchannel'             , 'Number of the used WIFI channel.'                                              , 'number', 'false', 'value'             ,''  ],
     ['ercd' , 'LastErrorCode'             , 'Error code of the last error occurred on this device'                          , 'string', 'false', 'text'              ,''  ],
     ['filf' , 'FilterLife'                , 'Estimated remaining filter life in hours.'                                     , 'number', 'false', 'value'             , 'hours' ],
-    ['fmod' , 'FanMode'                   , 'Mode of device'                                                                , 'string', 'false', 'switch'            ,'', {'FAN':'Fan', 'AUTO':'Auto'} ],
+    ['fmod' , 'FanMode'                   , 'Mode of device'                                                                , 'string', 'true', 'switch'            ,'', {'FAN':'Manual', 'AUTO':'Auto', 'OFF':'Off'} ],
     ['fnsp' , 'FanSpeed'                  , 'Current fan speed'                                                             , 'string', 'true',  'switch'            ,'', {'AUTO':'Auto', '0001':'1', '0002':'2', '0003':'3', '0004':'4', '0005':'5', '0006':'6', '0007':'7', '0008':'8', '0009':'9', '0010':'10' } ],
     ['fnst' , 'FanStatus'                 , 'Current Fan state; correlating to Auto-mode'                                   , 'string', 'false', 'text'              ,'' ],
     ['nmod' , 'Nightmode'                 , 'Night mode state'                                                              , 'string', 'true',  'switch.mode.moonlight'  ,'', {'OFF':'OFF', 'ON':'ON'} ],

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,20 @@
 {
     "common": {
         "name": "dysonairpurifier",
-        "version": "0.9.0",
+        "version": "0.9.1",
         "news": {
+            "0.9.1": {
+                "en": "TP05 and others are now supporting the OFF state.",
+                "de": "TP05 und andere unterstützen jetzt den AUS-Zustand.",
+                "ru": "TP05 и другие теперь поддерживают состояние ВЫКЛ.",
+                "pt": "TP05 e outros agora suportam o estado OFF.",
+                "nl": "TP05 en anderen ondersteunen nu de UIT-status.",
+                "fr": "TP05 et d'autres prennent désormais en charge l'état OFF.",
+                "it": "TP05 e altri supportano ora lo stato OFF.",
+                "es": "TP05 y otros ahora admiten el estado APAGADO.",
+                "pl": "TP05 i inne obsługują teraz stan WYŁĄCZONY.",
+                "zh-cn": "TP05和其他设备现在支持OFF状态。"
+            },
             "0.9.0": {
                 "en": "Support for new dyson 2 factor login procedure, new features and bugfixes.",
                 "de": "Unterstützung für neues Dyson 2-Faktor-Anmeldeverfahren, neue Funktionen und Bugfixes.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.dysonairpurifier",
-  "version": "0.9.0",
-  "description": "ioBroker Adapter for dyson air purifiers and fans",
+  "version": "0.9.1",
+  "description": "dyson air purifiers and fans",
   "author": {
     "name": "grizzelbee",
     "email": "open.source@hingsen.de"

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ Which is what the dyson app does also.
 
 ## Changelog
 
-### V0.9.0 (2021-04-26) (Still breathing)
+### V0.9.0 (2021-05-15) (Still breathing)
 * (grizzelbee) New: Added ioBroker sentry plugin to report errors automatically 
 * (grizzelbee) New: Added support for Dyson Pure Cool TP07 (438E)
 * (grizzelbee) New: Added support for Dyson 2-factor login method

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,9 @@ Which is what the dyson app does also.
 
 ## Changelog
 
+### V0.9.1 (2021-05-17) (Still breathing)
+* (grizzelbee) New: [#105](https://github.com/Grizzelbee/ioBroker.dysonairpurifier/issues/105) TP05 and others supporting the fmod token are now able to switch from Off to Auto- and manual-mode
+
 ### V0.9.0 (2021-05-15) (Still breathing)
 * (grizzelbee) New: Added ioBroker sentry plugin to report errors automatically 
 * (grizzelbee) New: Added support for Dyson Pure Cool TP07 (438E)


### PR DESCRIPTION
### V0.9.1 (2021-05-17) (Still breathing)
* (grizzelbee) New: [#105](https://github.com/Grizzelbee/ioBroker.dysonairpurifier/issues/105) TP05 and others supporting the fmod token are now able to switch from Off to Auto- and manual-mode
